### PR TITLE
Update besu.rb

### DIFF
--- a/besu.rb
+++ b/besu.rb
@@ -5,7 +5,7 @@ class Besu < Formula
   # update with: ./updateBesu.sh <new-version>
   sha256 "710aed228dcbe9b8103aef39e4431b0c63e73c3a708ce88bcd1ecfa1722ad307"
 
-  depends_on :java => "11+"
+  depends_on :openjdk => "11+"
 
   def install
     prefix.install "lib"

--- a/besu.rb
+++ b/besu.rb
@@ -5,7 +5,7 @@ class Besu < Formula
   # update with: ./updateBesu.sh <new-version>
   sha256 "710aed228dcbe9b8103aef39e4431b0c63e73c3a708ce88bcd1ecfa1722ad307"
 
-  depends_on :openjdk => "11+"
+  depends_on "openjdk" => "11+"
 
   def install
     prefix.install "lib"


### PR DESCRIPTION
Java is disabled 

192-168-1-16:~ kenm$ brew upgrade
Warning: Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the hyperledger/besu tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/hyperledger/homebrew-besu/besu.rb:8

Found this issue whilst upgrading to Big Sur