### PR TITLE
Fix Dependencies

### DIFF
--- a/besu.rb
+++ b/besu.rb
@@ -5,7 +5,7 @@ class Besu < Formula
   # update with: ./updateBesu.sh <new-version>
   sha256 "710aed228dcbe9b8103aef39e4431b0c63e73c3a708ce88bcd1ecfa1722ad307"
 
-  depends_on :java => "11+"
+  depends_on "openjdk" => "11+"
 
   def install
     prefix.install "lib"


### PR DESCRIPTION
Homebrew is trying to get rid of `:java`.  Replace it with `"openjdk"`

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

fixes https://github.com/hyperledger/besu/issues/1651