### PR TITLE
update to 21.10.0-RC3

### DIFF
--- a/besu.rb
+++ b/besu.rb
@@ -1,9 +1,9 @@
 class Besu < Formula
   desc "hyperledger besu ethereum client"
   homepage "https://github.com/hyperledger/besu"
-  url "https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/21.10.0-RC2/besu-21.10.0-RC2.zip"
+  url "https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/21.10.0-RC3/besu-21.10.0-RC3.zip"
   # update with: ./updateBesu.sh <new-version>
-  sha256 "4a279b515a2525ae42299ba74518a109444776b01c501ee4d96ea345c35194eb"
+  sha256 "3d4857589336717bf5e4e5ef711b9a7f3bc46b49e1cf5b3b6574a00ccc6eda94"
 
   depends_on "openjdk" => "11+"
 


### PR DESCRIPTION
bump homebrew to 21.10.0-RC3 since we published 21.10.0-RC2 last release

Signed-off-by: garyschulte <garyschulte@gmail.com>