### PR TITLE
releasing 22.7.0-RC3

### DIFF
--- a/besu.rb
+++ b/besu.rb
@@ -1,9 +1,9 @@
 class Besu < Formula
   desc "hyperledger besu ethereum client"
   homepage "https://github.com/hyperledger/besu"
-  url "https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.4.4/besu-22.4.4.zip"
+  url "https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.0-RC3/besu-22.7.0-RC3.zip"
   # update with: ./updateBesu.sh <new-version>
-  sha256 "84a7bee8fc35c78fd6d9e7bbdc5cd28c577d95487480bb03b9642a3111b71bc3"
+  sha256 "5de22445ab2a270cf33e1850cd28f1946442b7104738f0d1ac253a009c53414e"
 
   depends_on "openjdk" => "11+"
 


### PR DESCRIPTION
since the latest release version has significant known defects that have since been fixed, publishing the current 22.7.x release candidate.  

